### PR TITLE
Update getting-started.md

### DIFF
--- a/entity-framework/core/get-started/uwp/getting-started.md
+++ b/entity-framework/core/get-started/uwp/getting-started.md
@@ -102,6 +102,10 @@ Ya puede crear su migración inicial.
 
 * En el **Explorador de soluciones**, establezca el proyecto *Blogging.Migrations.Startup* como proyecto de inicio.
 
+* Ejecute `Install-Package Microsoft.EntityFrameworkCore.Design`
+
+  Este paquete es requerido por el paquete de herramientas Microsoft.EntityFrameworkCore.Tools.
+
 * Ejecute `Add-Migration InitialCreate`.
 
   Este comando aplica el scaffolding a una migración que crea el conjunto inicial de tablas para el modelo.


### PR DESCRIPTION
Si no se instala el paquete Microsoft.EntityFrameworkCore.Design se obtiene el siguiente mensaje:

Your startup project 'Blogging.Migrations.Startup' doesn't reference Microsoft.EntityFrameworkCore.Design. This package is required for the Entity Framework Core Tools to work. Ensure your startup project is correct, install the package, and try again.

El mismo cambio aplica para la versión en inglés.