### PR TITLE
Change 'name' to 'blog' for the context

### DIFF
--- a/entity-framework/ef6/saving/change-tracking/property-values.md
+++ b/entity-framework/ef6/saving/change-tracking/property-values.md
@@ -35,7 +35,7 @@ using (var context = new BloggingContext())
     string currentName1 = context.Entry(blog).Property(u => u.Name).CurrentValue;
 
     // Set the Name property to a new value
-    context.Entry(name).Property(u => u.Name).CurrentValue = "My Fancy Blog";
+    context.Entry(blog).Property(u => u.Name).CurrentValue = "My Fancy Blog";
 
     // Read the current value of the Name property using a string for the property name
     object currentName2 = context.Entry(blog).Property("Name").CurrentValue;


### PR DESCRIPTION
I think the first code block uses wrong 'name' for the context entry: 

    // Set the Name property to a new value
    context.Entry(name).Property(u => u.Name).CurrentValue = "My Fancy Blog";

I think it must be 'blog'